### PR TITLE
Fixes #168 Updated the entire Awards Section

### DIFF
--- a/applications/awards/models.py
+++ b/applications/awards/models.py
@@ -2,14 +2,24 @@ from django.db import models
 from ckeditor_uploader.fields import RichTextUploadingField
 from ckeditor.fields import RichTextField
 from django.utils.html import strip_tags
+from django.core.validators import MaxLengthValidator
+from imagekit.models import ProcessedImageField
+from imagekit.processors import ResizeToFit
 
 class Award(models.Model):
     award_id = models.AutoField(primary_key=True)
     title = RichTextField()
     by = models.CharField(max_length=255, null=True)
-    received_by = models.CharField(max_length=255, null=True, blank=True)  
-    description = RichTextUploadingField()
-    image = models.ImageField(upload_to='awards/images/', null=True, blank=True)
+    received_by = models.CharField(max_length=255, null=True, blank=True)
+    description = RichTextUploadingField(validators=[MaxLengthValidator(2000)])
+    image = ProcessedImageField(
+        upload_to='awards/images/',
+        processors=[ResizeToFit(50, 50)],
+        format='JPEG',
+        options={'quality': 90},
+        null=True,
+        blank=True
+    )
     published_date = models.DateField(auto_now_add=True)
 
     def __str__(self):
@@ -22,8 +32,3 @@ class Award(models.Model):
     @property
     def description_snippet(self):
         return ' '.join(strip_tags(self.description).split()[:50]) + ('...' if len(strip_tags(self.description).split()) > 50 else '')
-
-    def save(self, *args, **kwargs):
-        if len(strip_tags(self.description).split()) > 2000:
-            self.description = ' '.join(strip_tags(self.description).split()[:2000])
-        super().save(*args, **kwargs)

--- a/applications/awards/models.py
+++ b/applications/awards/models.py
@@ -21,4 +21,9 @@ class Award(models.Model):
 
     @property
     def description_snippet(self):
-        return ' '.join(strip_tags(self.description).split()[:50])
+        return ' '.join(strip_tags(self.description).split()[:50]) + ('...' if len(strip_tags(self.description).split()) > 50 else '')
+
+    def save(self, *args, **kwargs):
+        if len(strip_tags(self.description).split()) > 2000:
+            self.description = ' '.join(strip_tags(self.description).split()[:2000])
+        super().save(*args, **kwargs)

--- a/applications/awards/models.py
+++ b/applications/awards/models.py
@@ -1,16 +1,15 @@
 from django.db import models
-import datetime
 from ckeditor_uploader.fields import RichTextUploadingField
 from ckeditor.fields import RichTextField
-
-
-# Create your models here.
+from django.utils.html import strip_tags
 
 class Award(models.Model):
     award_id = models.AutoField(primary_key=True)
     title = RichTextField()
     by = models.CharField(max_length=255, null=True)
+    received_by = models.CharField(max_length=255, null=True, blank=True)  
     description = RichTextUploadingField()
+    image = models.ImageField(upload_to='awards/images/', null=True, blank=True)
     published_date = models.DateField(auto_now_add=True)
 
     def __str__(self):
@@ -18,5 +17,8 @@ class Award(models.Model):
 
     @property
     def title_stripped(self):
-        from django.utils.html import strip_tags
         return strip_tags(self.title)
+
+    @property
+    def description_snippet(self):
+        return ' '.join(strip_tags(self.description).split()[:50])

--- a/applications/awards/models.py
+++ b/applications/awards/models.py
@@ -14,7 +14,7 @@ class Award(models.Model):
     description = RichTextUploadingField(validators=[MaxLengthValidator(2000)])
     image = ProcessedImageField(
         upload_to='awards/images/',
-        processors=[ResizeToFit(50, 50)],
+        processors=[ResizeToFit(300, 300)],
         format='JPEG',
         options={'quality': 90},
         null=True,

--- a/applications/awards/urls.py
+++ b/applications/awards/urls.py
@@ -4,7 +4,6 @@ from . import views
 app_name = 'awards'
 
 urlpatterns = [
-    re_path(r'^(?P<id>[0-9])/$', views.award, name='award'),
+    re_path(r'^(?P<id>\d+)/$', views.award, name='award'),
     path('', views.index, name='index'),
-
 ]

--- a/applications/awards/views.py
+++ b/applications/awards/views.py
@@ -1,17 +1,18 @@
-from django.shortcuts import render ,redirect
+# applications/awards/views.py
+from django.shortcuts import render, redirect
 from .models import Award
 
-# Create your views here.
 def index(request):
     awards = Award.objects.all()
-    
+    for award in awards:
+        award.short_description = ' '.join(award.description.split()[:50]) 
+
     award_count = awards.count()
     return render(request, "awards/index.html", {"awards": awards, "award_count": award_count})
-
 
 def award(request, id):
     try:
         award = Award.objects.get(award_id=id)
         return render(request, "awards/award.html", {"award": award})
-    except:
+    except Award.DoesNotExist:
         return redirect('awards:index')

--- a/applications/awards/views.py
+++ b/applications/awards/views.py
@@ -1,11 +1,11 @@
-# applications/awards/views.py
 from django.shortcuts import render, redirect
 from .models import Award
 
 def index(request):
     awards = Award.objects.all()
     for award in awards:
-        award.short_description = ' '.join(award.description.split()[:50]) 
+        words = award.description.split()
+        award.short_description = ' '.join(words[:50]) + ('...' if len(words) > 50 else '')
 
     award_count = awards.count()
     return render(request, "awards/index.html", {"awards": awards, "award_count": award_count})

--- a/templates/awards/award.html
+++ b/templates/awards/award.html
@@ -8,35 +8,54 @@
 {% block body %}
     {% include 'globals/navbar.html' %}
     <div class="p-0 m-0 masthead-bg w-100 parallax shadow-sm" style="min-height:250px !important; height:270px !important; background-position-y: 270px;"></div>
-    <div style="height:150px; min-height:150px;">
+    <div style="height:150px; min-height:150px;"></div>
 
-    </div>
-    
-    <div class="events-container container text-left p-2 mx-auto">
+    <div class="container text-left p-2 mx-auto">
         <div class="card shadow m-4 bg-light">
-            <div class="row no-gutters p-3">
-                <div class="col">
-                    <div class="card-block px-2">
-                        <h1 class="card-title">{{ award.title|safe }}</h1>
-                        <!-- <p class="m-2 font-weight-normal mb-3"> -->
-                        <p class="m-2 font-weight-normal mb-3">
-                            <span class="d-inline-block pb-1 pb-md-0">
-                                <i class="fas fa-table"></i>
-                                {{ award.published_date|date:"d F, o" }}
-                                &nbsp;
-                            </span>
-                            <span class="d-inline-block">
-                                <i class="fas fa-user"></i>&nbsp;
-                                {{ award.by }}
-                            </span>
-                        </p>  
-                        <p>{{award.description|safe}}</p>
-                        <br>
-                    </div>
-                    <div class="w-100"></div>
+            <div class="card-body">
+                <div class="row">
+                    {% if award.image and award.image.url %}
+                        <div class="col-md-4">
+                            <img src="{{ award.image.url }}" alt="{{ award.title_stripped }}" class="img-fluid mb-3 award-image">
+                        </div>
+                        <div class="col-md-8">
+                    {% else %}
+                        <div class="col-12">
+                    {% endif %}
+                            <h1 class="card-title">{{ award.title|safe }}</h1>
+                            <p class="m-2 font-weight-normal mb-3">
+                                <span class="d-inline-block pb-1 pb-md-0">
+                                    <i class="fas fa-table"></i>
+                                    {{ award.published_date|date:"d F, o" }}
+                                    &nbsp;
+                                </span>
+                                <span class="d-inline-block">
+                                    <i class="fas fa-user"></i>&nbsp;
+                                    {{ award.by }}
+                                </span>
+                                {% if award.received_by %}
+                                    &nbsp;<span class="d-inline-block">
+                                        <i class="fas fa-user-check"></i>&nbsp;
+                                        {{ award.received_by }}
+                                    </span>
+                                {% endif %}
+                            </p>
+                            <p>{{ award.description|safe }}</p>
+                        </div>
                 </div>
             </div>
         </div>
     </div>
     {% include 'globals/footer.html' %}
+{% endblock %}
+
+{% block extra_css %}
+<style>
+    .award-image {
+        height: auto;
+        max-height: 300px; 
+        width: 100%;
+        object-fit: cover;
+    }
+</style>
 {% endblock %}

--- a/templates/awards/award.html
+++ b/templates/awards/award.html
@@ -15,7 +15,7 @@
             <div class="card-body">
                 <div class="row">
                     {% if award.image and award.image.url %}
-                        <div class="col-md-4">
+                        <div class="col-md-4 d-flex justify-content-center">
                             <img src="{{ award.image.url }}" alt="{{ award.title_stripped }}" class="img-fluid mb-3 award-image">
                         </div>
                         <div class="col-md-8">

--- a/templates/awards/index.html
+++ b/templates/awards/index.html
@@ -19,6 +19,16 @@
         object-fit: cover;
         margin-left: 15px;
     }
+    .award-item {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: 20px;
+        padding: 10px;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        background-color: #f8f9fa;
+    }
 
     @media (max-width: 576px) {
         .card-title {
@@ -59,7 +69,10 @@
                         <div class="award-item mb-4">
                             <div class="row">
                                 <div class="col-md-8">
-                                    <h2 class="award-title">{{ award.title|safe }}</h2>
+                                    <h2 class="award-title">
+                                        <a href="{% url 'awards:award' id=award.award_id %}">{{ award.title|safe }}</a>
+                                        
+                                    </h2>
                                     <p class="m-2 font-weight-normal mb-3">
                                         <span class="d-inline-block pb-1 pb-md-0">
                                             <i class="fas fa-table"></i>
@@ -80,13 +93,14 @@
                                     <p>{{ award.short_description|safe }}</p>
                                 </div>
                                 {% if award.image and award.image.url %}
-                                    <div class="col-md-4">
+                                    <div class="col-md-2">
                                         <img src="{{ award.image.url }}" alt="{{ award.title_stripped }}" class="img-fluid mb-3 award-image">
                                     </div>
                                 {% endif %}
                             </div>
-                            <hr>
+                          <hr>
                         </div>
+                        
                     {% endfor %}
                 </div>
             </div>

--- a/templates/awards/index.html
+++ b/templates/awards/index.html
@@ -8,21 +8,25 @@
 {% block extra_head %}
 <style>
     .card-title {
-        font-size: 2.5rem !important; 
+        font-size: 2.5rem !important;
     }
     .award-title {
-        font-size: 2rem !important; 
+        font-size: 2rem !important;
     }
-
+    .award-image {
+        max-height: 150px; 
+        width: 100%;
+        object-fit: cover;
+        margin-left: 15px;
+    }
 
     @media (max-width: 576px) {
         .card-title {
-            font-size: 1.5rem !important ; 
+            font-size: 1.5rem !important;
         }
         .award-title {
-            font-size: 1.25rem !important; 
+            font-size: 1.25rem !important;
         }
-       
     }
     @media (max-width: 400px) {
         .card-title {
@@ -43,7 +47,7 @@
     <div class="container text-left p-2 mx-auto">
         <div class="card shadow m-4 bg-light">
             <div class="card-body">
-                <h1 class="card-title">Awards:-</h1>
+                <h1 class="card-title">Awards:</h1>
                 <p class="m-2 font-weight-normal mb-3">
                     <span class="d-inline-block pb-1 pb-md-0">
                         <i class="fas fa-trophy"></i>
@@ -53,21 +57,36 @@
                 <div class="awards-list">
                     {% for award in awards %}
                         <div class="award-item mb-4">
-                            <h2 class="award-title">{{ award.title|safe }}</h2>
-                            <p class="m-2 font-weight-normal mb-3">
-                                <span class="d-inline-block pb-1 pb-md-0">
-                                    <i class="fas fa-table"></i>
-                                    {{ award.published_date|date:"d F, o" }}
-                                    &nbsp;
-                                </span>
-                                <span class="d-inline-block">
-                                    <i class="fas fa-user"></i>&nbsp;
-                                    {{ award.by }}
-                                </span>
-                            </p> 
-                            <p>{{  award.description|safe }}</p>
+                            <div class="row">
+                                <div class="col-md-8">
+                                    <h2 class="award-title">{{ award.title|safe }}</h2>
+                                    <p class="m-2 font-weight-normal mb-3">
+                                        <span class="d-inline-block pb-1 pb-md-0">
+                                            <i class="fas fa-table"></i>
+                                            {{ award.published_date|date:"d F, o" }}
+                                            &nbsp;
+                                        </span>
+                                        <span class="d-inline-block">
+                                            <i class="fas fa-user"></i>&nbsp;
+                                            {{ award.by }}
+                                        </span>
+                                        {% if award.received_by %}
+                                            &nbsp;<span class="d-inline-block">
+                                                <i class="fas fa-user-check"></i>&nbsp;
+                                                {{ award.received_by }}
+                                            </span>
+                                        {% endif %}
+                                    </p>
+                                    <p>{{ award.short_description|safe }}</p>
+                                </div>
+                                {% if award.image and award.image.url %}
+                                    <div class="col-md-4">
+                                        <img src="{{ award.image.url }}" alt="{{ award.title_stripped }}" class="img-fluid mb-3 award-image">
+                                    </div>
+                                {% endif %}
+                            </div>
+                            <hr>
                         </div>
-                        <hr>
                     {% endfor %}
                 </div>
             </div>

--- a/templates/awards/index.html
+++ b/templates/awards/index.html
@@ -92,7 +92,7 @@
                                     <p>{{ award.description_snippet|safe }}</p>
                                 </div>
                                 {% if award.image and award.image.url %}
-                                    <div class="col-md-3">
+                                    <div class="col-md-3 d-flex justify-content-center">
                                         <img src="{{ award.image.url }}" alt="{{ award.title_stripped }}" class="img-fluid mb-3 award-image">
                                     </div>
                                 {% endif %}

--- a/templates/awards/index.html
+++ b/templates/awards/index.html
@@ -71,7 +71,6 @@
                                 <div class="col-md-8">
                                     <h2 class="award-title">
                                         <a href="{% url 'awards:award' id=award.award_id %}">{{ award.title|safe }}</a>
-                                        
                                     </h2>
                                     <p class="m-2 font-weight-normal mb-3">
                                         <span class="d-inline-block pb-1 pb-md-0">
@@ -90,17 +89,16 @@
                                             </span>
                                         {% endif %}
                                     </p>
-                                    <p>{{ award.short_description|safe }}</p>
+                                    <p>{{ award.description_snippet|safe }}</p>
                                 </div>
                                 {% if award.image and award.image.url %}
-                                    <div class="col-md-2">
+                                    <div class="col-md-3">
                                         <img src="{{ award.image.url }}" alt="{{ award.title_stripped }}" class="img-fluid mb-3 award-image">
                                     </div>
                                 {% endif %}
                             </div>
                           <hr>
                         </div>
-                        
                     {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
### FIXES
**This PR fixes the issue #168 .**


### DESCRIPTION:-

**This PR does the following making changes in a number of files:-**

1. Updates the models.py of the awards app in the applications folder to incorporate  the image field 
`image = models.ImageField(upload_to='awards/images/', null=True, blank=True)` and also incorporate the received_by field 
`    received_by = models.CharField(max_length=255, null=True, blank=True)  `

2. Updates the views.py file in the same location, to display a limited portion of each award in the All Awards page or the index.html page and other fixes.

3. Updates the urls.py file in the same location to incorporate double-digit ids as well instead o ids ranging from [0-9] only.

4. Updates the award.html file so that the image can be displayed, received_by attribute be displayed and the whole content too. Lastly UI fixes.

5. Updates the index.html file so that all the awards are displayed in an orderly fashion with images right aligned and the description if too long contains a gist of the original content. Lastly UI fixes.

### PROOF OF WORK:-

**PORTION 1**

https://github.com/BitByte-TPC/alumni/assets/136831315/10e3d3d9-27b1-4e47-8b11-03f3bd379845

**This video shows two essential fixes:-**

1. The image attribute is added in the model and successful image upload is taking place.
2. The received_by attribute is added as well in the model and name can be added as to who received the award which in turn is displayed in the list of awards(index.html) and individual award page(award.html) with a proper icon. 
3. In the award list page(index.html) the images will be right aligned to maintain the UI of how the awards are displayed. Similarly awards with no images will display no image. In award.html or the individual award page the images will be left aligned if there is any image uploaded, if not nothing gets displayed and only the listed award is shown.


<img width="1512" alt="Screenshot 2024-07-07 at 5 17 33 AM" src="https://github.com/BitByte-TPC/alumni/assets/136831315/13db2422-2f2b-419c-95c6-65922987797c">

<img width="1319" alt="Screenshot 2024-07-07 at 5 18 44 AM" src="https://github.com/BitByte-TPC/alumni/assets/136831315/cd230e44-e483-46e2-ae10-7a2cdfcd1a2b">

These two images show the image displayed both in the index.html page with all the awards, and in the award.html page where only the specified award is displayed.

**PORTION 2**


https://github.com/BitByte-TPC/alumni/assets/136831315/743632db-7f30-4ec5-a039-d070d716abe1

**This video shows the fix:-**

1. Instead of a large chunk of text in the description, it will trim off the receding portion displaying just a segment of the portion in the preview region in the index.html page in contrary to the screenshot provided in the issue where the entire description is getting displayed without any trim.


https://github.com/BitByte-TPC/alumni/assets/136831315/bbf3ff16-a906-4ab1-8bf7-bdb2313e8230

This video is in accordance with the previous video showing that while in the award-list page or the index.html page the long text gets trimmed to a smaller chunk and when the corresponding award page of that particular award(award.html) page is opened, the entire text is displayed properly.

The UI too has been fixed accordingly.


Thank You.
