### PR TITLE
feat(blogs): added functionality to approve or discard blogs by admin

### DIFF
--- a/applications/adminportal/views.py
+++ b/applications/adminportal/views.py
@@ -1,3 +1,4 @@
+from uu import Error
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -15,9 +16,10 @@ from django.utils.html import strip_tags
 from datetime import date, datetime
 
 from applications.alumniprofile.models import Profile
+from applications.blog.models import Blog
 from applications.events_news.models import Event
 from .models import EmailTemplate, EmailHistory
-
+from django.db.models import Q
 import pytz
 
 ALLOWED_RECIPIENTS_PER_DAY = 500
@@ -66,7 +68,8 @@ def get_rendered_emails(from_email, email_template, recipients):
     login_url=reverse_lazy('home')
 )
 def index(request):
-    return render(request, 'adminportal/index.html')
+    blogs = Blog.objects.filter(Q(approved=False))
+    return render(request, 'adminportal/index.html', {'blogs': blogs})
 
 
 #Function to convert datetime from naive to offset

--- a/applications/blog/models.py
+++ b/applications/blog/models.py
@@ -47,6 +47,7 @@ class Blog(models.Model):
         
         blog_type = models.CharField(choices=Constants.TYPE, max_length=15,default='S')
         campaign_id = models.ForeignKey(Campaign, on_delete=models.CASCADE, null=True, blank=True)
+        approved = models.BooleanField(default=False)
 
         def __str__(self):
             return self.title

--- a/applications/blog/urls.py
+++ b/applications/blog/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('<int:blog_id>/', views.blog_detail, name='blog_detail'),
     path('newBlog/', views.blog_create, name='blog_create'),
     path('<int:blog_id>/edit/', views.blog_update, name='blog_update'),
+    path('<int:blog_id>/approve/', views.blog_approve, name='blog_approve'),
     path('<int:blog_id>/delete/', views.blog_delete, name='blog_delete'),
     path('<int:reply_id>/deleteReply/', views.reply_delete, name='reply_delete'),
     

--- a/applications/blog/views.py
+++ b/applications/blog/views.py
@@ -76,6 +76,19 @@ def blog_update(request,blog_id):
         context={'form':form}
         return render(request,'blog/blog_form.html',context)
     except:
+        return redirect('blog:index')
+
+@login_required
+def blog_approve(request,blog_id):
+    try:
+        blog=Blog.objects.get(blog_id=blog_id)
+        form=BlogForm(instance=blog)
+        if(request.method)=='POST':
+            blog.approved = True
+            blog.save() 
+        context={'form':blog}
+        return render(request,'blog/blog_form.html',context)
+    except:
         return redirect('blog:index') 
    
 @login_required

--- a/templates/adminportal/index.html
+++ b/templates/adminportal/index.html
@@ -26,10 +26,97 @@
             </div>
         </div>
     </section> -->
-    
-    <div class="container px-5 px-sm-2 my-5">
-        Dashboard page to be updated... :)
+<style>
+    .hidden {
+        display: none;
+    }
+    .actions {
+        display: block;
+    }
+    @media only screen and (max-width: 600px) {
+        .actions {
+            display: none;
+        }
+    }
+</style>
+<div class="container px-5 px-sm-2 my-5 bg-green-500">
+    <h3 class="mb-4">Blogs to be approved</h3>
+    <div class="container mx-auto mt-8" style="background-color: blue;">
+        {% if blogs %}
+        <table class="bg-white" style="width: 100%;">
+            <thead>
+                <tr>
+                    <th class="py-2 px-4 border-b text-left">Title</th>
+                    <th class="py-2 px-4 border-b text-left actions">Details</th>
+                    <th class="py-2 px-4 border-b text-left">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                    {% for blog in blogs %}
+                        <tr class="border">
+                            <td
+                                class="py-2 px-4 border-b max-w-xs overflow-hidden overflow-ellipsis whitespace-nowrap"
+                            >
+                                {{blog.title}}
+                            </td>
+                            <td class="py-2 px-4 border-b flex space-x-2 space-y-2 actions">
+                                <button
+                                    class="text-primary px-4 py-2 rounded"
+                                    onclick="toggleDetails(this)"
+                                    data-id="{{blog.id}}"
+                                    data-title="{{blog.title}}"
+                                    data-description="{{blog.description}}"
+                                >Show Details</button>
+                            </td>
+                            <td class="py-2 px-4 border-b flex">
+                                <button
+                                    class="text-primary px-4 py-2 rounded"
+                                    style="width: 120px;"
+                                    onclick="$.post('/blog/{{blog.id}}/approve/')"
+                                >
+                                    Approve
+                                </button>
+                                <button
+                                    class="text-primary px-4 py-2 rounded"
+                                    style="width: 120px;"
+                                    onclick="$.post('/blog/{{blog.id}}/delete/')"
+                                >
+                                    Discard
+                                </button>
+                            </td>
+                        </tr>
+                    {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="text-center p-2 text-white">No remaining blogs for approval</p>
+    {% endif %}
     </div>
+    <div class="details_modal flex flex-col hidden" style="position: fixed; top: 0; left: 0; height: 100vh; width: 100%; backdrop-filter: blur(10px); z-index: 100;">
+        <div class="border p-2" style="position: relative; height: 400px; width: 600px; max-width: 90vw; background-color: white; margin: auto; margin-top: 200px;">
+            <h4 class="mb-4 title"></h4>
+            <h5 class="description"></h5>
+            <div style="position: absolute; bottom: 0; left: 0; width: 100%; display: flex; justify-content: space-between;">
+                <Button onclick="toggleDetails()" class="text-primary bg-secondary p-2" style="width: 100%;">Hide</Button>
+            </div>
+        </div>
+    </div>
+    <script>
+        function toggleDetails(button) {
+            console.log(button)
+            const detailsDiv = document.querySelector(".details_modal")
+            const titleDiv = document.querySelector(".title")
+            const descriptionDiv = document.querySelector(".description")
+            if(!button) return detailsDiv.classList.add('hidden')
+            if (detailsDiv.classList.contains('hidden')) {
+                detailsDiv.classList.remove('hidden');
+                titleDiv.textContent = button.getAttribute("data-title");
+                descriptionDiv.textContent = button.getAttribute("data-description");
+            } else {
+                detailsDiv.classList.add('hidden');
+            }
+        }
+    </script>
+</div>
 
-    {% include 'globals/footer.html' %}
-{% endblock %}
+{% include 'globals/footer.html' %} {% endblock %}


### PR DESCRIPTION
## Work done in this PR:
- added a new field `approved` in blogs model in `application/blog/models.py`
- updated the admin dashboard and added a responsive blogs table to show pending blogs for approval or discarding in `templates/adminportal/index.html`
- added new route to approve blogs in `applications\blog\urls.py`

## Proof of work:

https://github.com/user-attachments/assets/bfbc299d-703b-4b34-967d-07f06ff0d3e4

### in case no blogs are awaiting approval:

![Screenshot 2024-07-19 184725](https://github.com/user-attachments/assets/b631ffa0-4ac5-444e-9e16-5f57a0b8580d)

### final notes:
file changes
1. Frontend: `templates/adminportal/index.html`
2. Backend:
   - `applications/adminportal/views.py`
   - `applications/blog/models.py`
   - `applications/blog/urls.py`
   - `applications/blog/views.py`
 3. the demidata I used:
         blogs = [
        {"id": 1, "title": "hello this is title 1", "description": "description very very short though"},
        {"id": 2, "title": "hello this is title 2", "description": "description very very short though"},
        {"id": 3, "title": "hello this is title 3", "description": "description very very short though"},
        {"id": 4, "title": "hello this is title 4", "description": "description very very short though"},
        {"id": 5, "title": "hello this is title 5", "description": "description very very short though"},
    ]
  
@SamakshAgarwal1112 Please let me know if any more changes are required
